### PR TITLE
Add includeUrl option to control URL display in tab listings

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -98,7 +98,9 @@ export async function createMcpServer(
           .boolean()
           .optional()
           .default(false)
-          .describe("Include full URLs in the output"),
+          .describe(
+            "Include full URLs in the output (default: false, shows hostname only)"
+          ),
       },
     },
     async (args) => {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -92,16 +92,23 @@ export async function createMcpServer(
     "list_tabs",
     {
       description:
-        "List all open tabs in the user's browser with their titles, URLs, and tab references",
-      inputSchema: {},
+        "List all open tabs in the user's browser with their titles, URLs, and tab references. Use includeUrl option to show full URLs when needed.",
+      inputSchema: {
+        includeUrl: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Include full URLs in the output"),
+      },
     },
-    async () => {
+    async (args) => {
+      const { includeUrl = false } = args;
       const tabs = await listTabs(options);
       return {
         content: [
           {
             type: "text",
-            text: view.formatList(tabs),
+            text: view.formatList(tabs, includeUrl),
           },
         ],
       };

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -104,7 +104,7 @@ export async function createMcpServer(
       },
     },
     async (args) => {
-      const { includeUrl = false } = args;
+      const { includeUrl } = args;
       const tabs = await listTabs(options);
       return {
         content: [

--- a/src/view.ts
+++ b/src/view.ts
@@ -12,20 +12,26 @@ export function parseTabRef(tabRef: string): TabRef | null {
   return { windowId, tabId };
 }
 
-function truncateUrl(tab: Tab, over: number = 120): string {
-  const url = tab.url;
-  if (url.length <= over) return url;
-  return url.slice(0, over) + "...";
+function getDomain(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
 }
 
-export function formatList(tabs: Tab[]): string {
-  const list = tabs.map(formatListItem).join("\n");
+export function formatList(tabs: Tab[], includeUrl: boolean = false): string {
+  const list = tabs.map((tab) => formatListItem(tab, includeUrl)).join("\n");
   const header = `### Current Tabs (${tabs.length} tabs exists)\n`;
   return header + list;
 }
 
-export function formatListItem(tab: Tab): string {
-  return `- ${formatTabRef(tab)} [${tab.title}](${truncateUrl(tab)})`;
+export function formatListItem(tab: Tab, includeUrl: boolean = false): string {
+  if (includeUrl) {
+    return `- ${formatTabRef(tab)} [${tab.title}](${tab.url})`;
+  } else {
+    return `- ${formatTabRef(tab)} ${tab.title} (${getDomain(tab.url)})`;
+  }
 }
 
 export function formatTabContent(tab: TabContent): string {

--- a/src/view.ts
+++ b/src/view.ts
@@ -14,7 +14,8 @@ export function parseTabRef(tabRef: string): TabRef | null {
 
 function getDomain(url: string): string {
   try {
-    return new URL(url).hostname;
+    const u = new URL(url);
+    return u.port ? `${u.hostname}:${u.port}` : u.hostname;
   } catch {
     return url;
   }

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -99,6 +99,8 @@ describe("MCP Server", () => {
     });
 
     it("should include full URLs when includeUrl is true", async () => {
+      vi.mocked(mockBrowserInterface.getTabList).mockResolvedValue(mockTabs);
+
       const result = await client.callTool({
         name: "list_tabs",
         arguments: { includeUrl: true },

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -93,6 +93,20 @@ describe("MCP Server", () => {
       expect(result.content).toHaveLength(1);
       const text = (result.content as any)[0].text;
       expect(text).toContain("### Current Tabs (3 tabs exists)");
+      expect(text).toContain("ID:1001:2001 Example Page (example.com)");
+      expect(text).toContain("ID:1001:2002 GitHub (github.com)");
+      expect(text).toContain("ID:1002:2003 Test Site (test.com)");
+    });
+
+    it("should include full URLs when includeUrl is true", async () => {
+      const result = await client.callTool({
+        name: "list_tabs",
+        arguments: { includeUrl: true },
+      });
+
+      expect(result.content).toHaveLength(1);
+      const text = (result.content as any)[0].text;
+      expect(text).toContain("### Current Tabs (3 tabs exists)");
       expect(text).toContain(
         "ID:1001:2001 [Example Page](https://example.com/page1)"
       );


### PR DESCRIPTION
## Summary

- Add optional `includeUrl` parameter to `list_tabs` tool for controlling URL display format
- Default behavior (includeUrl: false) shows tab ID, title, and domain/port only
- Optional behavior (includeUrl: true) shows full URLs as markdown links
- Include port numbers in domain display for better clarity (e.g., localhost:3000)

## Changes

- **src/mcp.ts**: Add `includeUrl` parameter to tool schema with clear description
- **src/view.ts**: Implement URL display control logic and improve domain extraction
- **tests/mcp.test.ts**: Add comprehensive test coverage for both display modes

## Test plan

- [x] Unit tests pass (20 tests)
- [x] E2E tests pass (4 browser integration tests)
- [x] Verified both display modes work correctly
- [x] Port numbers are properly included in domain display

Resolves #8