### PR TITLE
Add URL metadata and improve tab name formatting

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -184,7 +184,7 @@ export async function createMcpServer(
         contents: [
           {
             uri: uri.href,
-            name: tab.title,
+            name: view.formatTabName(tab),
             text,
             mimeType: "text/markdown",
             size: new Blob([text]).size,
@@ -202,7 +202,7 @@ export async function createMcpServer(
         return {
           resources: tabs.map((tab) => ({
             uri: view.formatUri(tab),
-            name: tab.title,
+            name: view.formatTabName(tab),
             mimeType: "text/markdown",
           })),
         };
@@ -224,7 +224,7 @@ export async function createMcpServer(
         contents: [
           {
             uri: uri.href,
-            name: tab.title,
+            name: view.formatTabName(tab),
             mimeType: "text/markdown",
             text,
             size: new Blob([text]).size,

--- a/src/view.ts
+++ b/src/view.ts
@@ -21,6 +21,10 @@ function getDomain(url: string): string {
   }
 }
 
+export function formatTabName(tab: { title: string; url: string }): string {
+  return `${tab.title} (${getDomain(tab.url)})`;
+}
+
 export function formatList(tabs: Tab[], includeUrl: boolean = false): string {
   const list = tabs.map((tab) => formatListItem(tab, includeUrl)).join("\n");
   const header = `### Current Tabs (${tabs.length} tabs exists)\n`;
@@ -31,15 +35,15 @@ export function formatListItem(tab: Tab, includeUrl: boolean = false): string {
   if (includeUrl) {
     return `- ${formatTabRef(tab)} [${tab.title}](${tab.url})`;
   } else {
-    return `- ${formatTabRef(tab)} ${tab.title} (${getDomain(tab.url)})`;
+    return `- ${formatTabRef(tab)} ${formatTabName(tab)}`;
   }
 }
 
 export function formatTabContent(tab: TabContent): string {
   return `
 ---
-title: ${tab.title}
 url: ${tab.url}
+title: ${tab.title}
 ---
 ${tab.content}
 `.trimStart();

--- a/src/view.ts
+++ b/src/view.ts
@@ -39,6 +39,7 @@ export function formatTabContent(tab: TabContent): string {
   return `
 ---
 title: ${tab.title}
+url: ${tab.url}
 ---
 ${tab.content}
 `.trimStart();
@@ -47,6 +48,5 @@ ${tab.content}
 export const uriTemplate = "tab://{windowId}/{tabId}";
 
 export function formatUri(ref: TabRef): string {
-  // TODO give domain & title for incremental search
   return `tab://${ref.windowId}/${ref.tabId}`;
 }

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -18,7 +18,7 @@ const mockBrowserInterface: BrowserInterface = {
 vi.mock("../src/browser/browser.js", async (importOriginal) => {
   const actual = await importOriginal();
   return {
-    ...actual,
+    ...(actual as any),
     getInterface: vi.fn(() => mockBrowserInterface),
   };
 });
@@ -273,7 +273,7 @@ describe("MCP Server", () => {
         expect(result.contents).toHaveLength(1);
         const content = result.contents[0];
         expect(content.uri).toBe("tab://current");
-        expect(content.name).toBe(mockPageContent.title);
+        expect(content.name).toBe(`${mockPageContent.title} (example.com)`);
         expect(content.mimeType).toBe("text/markdown");
         expect(content.text).toContain("---");
         expect(content.text).toContain("title: " + mockPageContent.title);
@@ -327,7 +327,7 @@ describe("MCP Server", () => {
         expect(result.contents).toHaveLength(1);
         const content = result.contents[0];
         expect(content.uri).toBe("tab://1001/2001");
-        expect(content.name).toBe(mockPageContent.title);
+        expect(content.name).toBe(`${mockPageContent.title} (example.com)`);
         expect(content.mimeType).toBe("text/markdown");
         expect(content.text).toContain("---");
         expect(content.text).toContain("title: " + mockPageContent.title);
@@ -393,7 +393,9 @@ describe("MCP Server", () => {
 
         // Verify first tab resource
         const firstTabResource = tabResources[0];
-        expect(firstTabResource.name).toBe(mockTabs[0].title);
+        expect(firstTabResource.name).toBe(
+          `${mockTabs[0].title} (example.com)`
+        );
         expect(firstTabResource.mimeType).toBe("text/markdown");
       });
 
@@ -410,7 +412,15 @@ describe("MCP Server", () => {
 
         // Verify tab resources match mock data
         tabResources.forEach((resource, index) => {
-          expect(resource.name).toBe(mockTabs[index].title);
+          const expectedDomain =
+            index === 0
+              ? "example.com"
+              : index === 1
+                ? "github.com"
+                : "test.com";
+          expect(resource.name).toBe(
+            `${mockTabs[index].title} (${expectedDomain})`
+          );
           expect(resource.mimeType).toBe("text/markdown");
           expect(resource.uri).toBe(
             `tab://${mockTabs[index].windowId}/${mockTabs[index].tabId}`

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -18,7 +18,7 @@ const mockBrowserInterface: BrowserInterface = {
 vi.mock("../src/browser/browser.js", async (importOriginal) => {
   const actual = await importOriginal();
   return {
-    ...(actual as any),
+    ...(actual as object),
     getInterface: vi.fn(() => mockBrowserInterface),
   };
 });
@@ -412,12 +412,7 @@ describe("MCP Server", () => {
 
         // Verify tab resources match mock data
         tabResources.forEach((resource, index) => {
-          const expectedDomain =
-            index === 0
-              ? "example.com"
-              : index === 1
-                ? "github.com"
-                : "test.com";
+          const expectedDomain = new URL(mockTabs[index].url).hostname;
           expect(resource.name).toBe(
             `${mockTabs[index].title} (${expectedDomain})`
           );


### PR DESCRIPTION
## Summary
- Add URL to front matter in formatTabContent for better metadata
- Add formatTabName function for consistent title display with domain info
- Update MCP resource names to include domain information for better tab identification

## Changes
- Added `url` field to front matter in tab content formatting
- Created `formatTabName` function to display tab titles with domain info
- Updated `formatListItem` to use consistent naming format
- Updated MCP resource names to include domain for better identification
- Updated tests to match new naming format

## Test plan
- [x] Unit tests pass
- [x] E2E tests pass
- [x] Tab names now display as "Title (domain.com)" format
- [x] Resource names consistently include domain information