### PR TITLE
docs: add --max-content-chars option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The server accepts optional command line arguments for configuration:
 - `--application-name` - Application name to control (default: "Google Chrome")
 - `--exclude-hosts` - Comma-separated list of domains to exclude from tab listing and content access
 - `--check-interval` - Interval in milliseconds to check for tab changes and notify clients (default: 3000, set to 0 to disable)
+- `--max-content-chars` - Maximum content characters per single read (default: 20000)
 
 #### Experimental Safari Support
 


### PR DESCRIPTION
## Summary

- Add missing documentation for the `--max-content-chars` command line option in README.md

## Test plan

- [x] Verified the option exists in the codebase (`src/cli.ts`)
- [x] Updated Command Line Options section with accurate default value
- [x] Maintained consistent formatting with existing options