### PR TITLE
Support Arc browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ Limited Safari support is available. Note that Safari lacks unique tab IDs, maki
 npx @pokutuna/mcp-chrome-tabs --application-name=Safari --experimental-browser=safari
 ```
 
+#### Experimental Arc Browser Support
+
+Arc Browser support is available. Arc is Chrome-based and supports JavaScript execution from Apple Events:
+
+```bash
+npx @pokutuna/mcp-chrome-tabs --application-name=Arc --experimental-browser=arc
+```
+
 ## MCP Features
 
 ### Tools

--- a/src/browser/arc.ts
+++ b/src/browser/arc.ts
@@ -1,0 +1,146 @@
+import type { BrowserInterface, TabRef, Tab, TabContent } from "./browser.js";
+import {
+  escapeAppleScript,
+  executeAppleScript,
+  separator,
+} from "./osascript.js";
+
+/*
+Arc browser implementation notes
+- Tab/Window IDs are UUIDs (unlike Chrome's numeric IDs)
+- The return value of "execute javascript" may be wrapped in "..." and escaped (e.g., \u003C), so decode it with JSON.parse
+- Directly telling the active tab (front window/active tab) can fail depending on the environment;
+  even when unspecified, first resolve the active tab's windowId/tabId and execute via the ID-targeted path for stability
+*/
+
+async function getArcTabList(applicationName: string): Promise<Tab[]> {
+  const sep = separator();
+  const appleScript = `
+    tell application "${applicationName}"
+      set output to ""
+      repeat with aWindow in (every window)
+        set windowId to id of aWindow
+        repeat with aTab in (every tab of aWindow)
+          set tabId to id of aTab
+          set tabTitle to title of aTab
+          set tabURL to URL of aTab
+          set output to output & windowId & "${sep}" & tabId & "${sep}" & tabTitle & "${sep}" & tabURL & "\\n"
+        end repeat
+      end repeat
+      return output
+    end tell
+  `;
+
+  const result = await executeAppleScript(appleScript);
+  const lines = result.trim().split("\n");
+  const tabs: Tab[] = [];
+  for (const line of lines) {
+    const [wId, tId, title, url] = line.split(sep);
+    if (!/^https?:\/\//.test(url)) continue;
+
+    tabs.push({
+      windowId: wId,
+      tabId: tId,
+      title: title.trim(),
+      url: url.trim(),
+    });
+  }
+  return tabs;
+}
+
+async function getActiveTabRef(applicationName: string): Promise<TabRef> {
+  const sep = separator();
+  const appleScript = `
+    try
+      tell application "${applicationName}"
+        set wId to id of front window
+        set tId to id of active tab of front window
+        return wId & "${sep}" & tId
+      end tell
+    on error errMsg
+      return "ERROR" & "${sep}" & errMsg
+    end try
+  `;
+  const result = await executeAppleScript(appleScript);
+  if (result.startsWith(`ERROR${sep}`)) {
+    throw new Error(result.split(sep)[1]);
+  }
+  const [windowId, tabId] = result.split(sep);
+  return { windowId: windowId.trim(), tabId: tabId.trim() };
+}
+
+async function getPageContent(
+  applicationName: string,
+  tab?: TabRef | null
+): Promise<TabContent> {
+  const sep = separator();
+  const inner = `
+    set tabTitle to title
+    set tabURL to URL
+    set tabContent to execute javascript "document.documentElement.outerHTML"
+    return tabTitle & "${sep}" & tabURL & "${sep}" & tabContent
+  `;
+
+  const targetTab: TabRef = tab ?? (await getActiveTabRef(applicationName));
+
+  const appleScript = `
+    try
+      tell application "${applicationName}"
+        tell window id "${targetTab.windowId}"
+          tell tab id "${targetTab.tabId}"
+            with timeout of 3 seconds
+              ${inner}
+            end timeout
+          end tell
+        end tell
+      end tell
+    on error errMsg
+      return "ERROR" & "${sep}" & errMsg
+    end try
+  `;
+
+  const scriptResult = await executeAppleScript(appleScript);
+  if (scriptResult.startsWith(`ERROR${sep}`)) {
+    throw new Error(scriptResult.split(sep)[1]);
+  }
+
+  const parts = scriptResult.split(sep).map((part) => part.trim());
+  if (parts.length < 3) {
+    throw new Error("Failed to read the tab content");
+  }
+
+  const [title, url, rawContent] = parts;
+
+  // Arc's "execute javascript" return string may be wrapped in "..." and escaped like \u003C.
+  // In such cases, decode with JSON.parse to restore the raw HTML.
+  let content = rawContent;
+  if (content.startsWith('"') && content.endsWith('"')) {
+    try {
+      content = JSON.parse(content);
+    } catch {
+      // If decoding fails, return the value as-is
+    }
+  }
+
+  return {
+    title,
+    url,
+    content,
+  };
+}
+
+async function openURL(applicationName: string, url: string): Promise<void> {
+  const escapedUrl = escapeAppleScript(url);
+  const appleScript = `
+    tell application "${applicationName}"
+      open location "${escapedUrl}"
+    end tell
+  `;
+  await executeAppleScript(appleScript);
+}
+
+export const arcBrowser: BrowserInterface = {
+  getTabList: getArcTabList,
+  getPageContent,
+  openURL,
+};

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -1,4 +1,4 @@
-export type Browser = "chrome" | "safari";
+export type Browser = "chrome" | "safari" | "arc";
 
 export type TabRef = { windowId: string; tabId: string };
 
@@ -24,10 +24,14 @@ export type BrowserInterface = {
 
 import { chromeBrowser } from "./chrome.js";
 import { safariBrowser } from "./safari.js";
+import { arcBrowser } from "./arc.js";
 
 export function getInterface(browser: Browser): BrowserInterface {
   if (browser === "safari") {
     return safariBrowser;
+  }
+  if (browser === "arc") {
+    return arcBrowser;
   }
   return chromeBrowser;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,7 @@ OPTIONS:
 
   --experimental-browser=<b>  Browser implementation to use
                               (default: "chrome")
-                              Options: "chrome", "safari"
+                              Options: "chrome", "safari", "arc"
 
   --max-content-chars=<chars> Maximum content characters per single read
                               (default: 20000)
@@ -96,8 +96,9 @@ function parseCliArgs(args: string[]): CliOptions {
   function parseBrowserOption(browser: string): Browser {
     if (browser === "" || browser === "chrome") return "chrome";
     if (browser === "safari") return "safari";
+    if (browser === "arc") return "arc";
     throw new Error(
-      `Invalid --experimental-browser option: "${browser}". Use "chrome" or "safari".`
+      `Invalid --experimental-browser option: "${browser}". Use "chrome", "safari", or "arc".`
     );
   }
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -5,7 +5,7 @@ export function formatTabRef(tab: Tab): string {
 }
 
 export function parseTabRef(tabRef: string): TabRef | null {
-  const match = tabRef.match(/ID:(\d+):(\d+)$/);
+  const match = tabRef.match(/^ID:([^:]+):([^:]+)$/);
   if (!match) return null;
   const windowId = match[1];
   const tabId = match[2];


### PR DESCRIPTION
## Overview
Added experimental support for [Arc Browser](https://arc.net).

## Usage
Start the server with the following command:

```bash
npm run dev -- --application-name=Arc --experimental-browser=arc
```

## Verified environment
macOS 15.6 (24G84), arm64
Node.js v24.4.0 / npm 11.4.2
Arc: Version 1.107.0 (66519), Chromium Engine 139.0.7258.67

## Notes

Thank you for this awesome tool. I use Arc as my daily browser and would love to see it supported. I'm proposing this change to add that functionality.

I understand if you don't use Arc or if this change would increase the maintenance burden. Please feel free to close this PR if that's the case.

If you do decide to merge this, I'm happy to help with any future maintenance related to this feature.