### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "pokutuna"
+    assignees:
+      - "pokutuna"
+    commit-message:
+      prefix: "deps"
+      include: "scope"


### PR DESCRIPTION
## Summary

Add Dependabot configuration to automatically manage npm dependency updates.

## Changes

- Added `.github/dependabot.yml` configuration file
- Configured weekly dependency checks for npm ecosystem
- Set up automatic PR creation with limits and assignments

## Configuration Details

- **Schedule**: Weekly dependency checks
- **PR Limit**: Maximum 10 open PRs at once
- **Auto-assignment**: @pokutuna as reviewer and assignee
- **Commit prefix**: "deps" for dependency updates

## Test Plan

- [x] Configuration file validates correctly
- [x] File is properly committed to the repository
- [ ] Dependabot will create PRs according to schedule (to be verified after merge)