### PR TITLE
feat: add --version option to CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,13 +1,9 @@
 #!/usr/bin/env node
 
-import { createRequire } from "module";
 import { parseArgs } from "util";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { createMcpServer, McpServerOptions } from "./mcp.js";
+import { createMcpServer, McpServerOptions, packageVersion } from "./mcp.js";
 import type { Browser } from "./browser/browser.js";
-
-const require = createRequire(import.meta.url);
-const { version } = require("../package.json") as { version: string };
 
 type CliOptions = McpServerOptions & {
   help: boolean;
@@ -157,7 +153,7 @@ function parseCliArgs(args: string[]): CliOptions {
 async function main(): Promise<void> {
   const options = parseCliArgs(process.argv.slice(2));
   if (options.version) {
-    console.log(version);
+    console.log(await packageVersion());
     process.exit(0);
   }
   if (options.help) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,12 +1,17 @@
 #!/usr/bin/env node
 
+import { createRequire } from "module";
 import { parseArgs } from "util";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createMcpServer, McpServerOptions } from "./mcp.js";
 import type { Browser } from "./browser/browser.js";
 
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json") as { version: string };
+
 type CliOptions = McpServerOptions & {
   help: boolean;
+  version: boolean;
 };
 
 function showHelp(): void {
@@ -46,6 +51,7 @@ BROWSER OPTIONS:
 
 OTHER OPTIONS:
   --help                      Show this help message
+  --version                   Show version number
 
 
 REQUIREMENTS:
@@ -100,6 +106,10 @@ function parseCliArgs(args: string[]): CliOptions {
         type: "boolean",
         default: false,
       },
+      version: {
+        type: "boolean",
+        default: false,
+      },
     },
     allowPositionals: false,
     tokens: true,
@@ -139,12 +149,17 @@ function parseCliArgs(args: string[]): CliOptions {
       1000
     ),
     help: values.help,
+    version: values.version,
   };
   return parsed;
 }
 
 async function main(): Promise<void> {
   const options = parseCliArgs(process.argv.slice(2));
+  if (options.version) {
+    console.log(version);
+    process.exit(0);
+  }
   if (options.help) {
     showHelp();
     process.exit(0);

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -66,7 +66,7 @@ async function getTab(
   }
 }
 
-async function packageVersion(): Promise<string> {
+export async function packageVersion(): Promise<string> {
   const packageJsonText = await readFile(
     join(dirname(fileURLToPath(import.meta.url)), "../package.json"),
     "utf8"


### PR DESCRIPTION
## Summary

- Add `--version` CLI option that prints the package version from `package.json` and exits
- Version is read at runtime using `createRequire` to import `package.json`

## Confirmed

- `npm run dev -- --version` outputs `0.8.2`
- `npm run build` succeeds
- `npm run test` passes (4 files, 33 tests)