### PR TITLE
ci: enable e2e via TCC pre-authorization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,8 +68,11 @@ jobs:
         # Launch Chrome and run progressively-deeper AppleScript to isolate
         # which command hangs (TCC vs window enumeration vs JS execution).
         # macOS has no `timeout`; use AppleScript's `with timeout` instead.
+        # `-a` without `-g` brings Chrome to front; pass a URL so Chrome opens
+        # a window (CI runners without a logged-in GUI may otherwise launch
+        # Chrome with no windows, making window-querying AppleEvents hang).
         run: |
-          open -ga "Google Chrome"
+          open -a "Google Chrome" "https://example.com"
           sleep 5
           set +e
           probe() {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,8 +75,17 @@ jobs:
           # Register Chrome with LaunchServices before invoking by name.
           /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister \
             -f "/Applications/Google Chrome.app" || true
-          open -a "/Applications/Google Chrome.app" "https://example.com"
-          sleep 5
+          # Launch Chrome directly in background with a URL to force window
+          # creation. 'open -a' alone starts Chrome without windows on
+          # headless-ish runners.
+          "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+            --no-first-run --no-default-browser-check \
+            "https://example.com" >/tmp/chrome.log 2>&1 &
+          sleep 6
+          echo "--- /tmp/chrome.log tail:"
+          tail -30 /tmp/chrome.log || true
+          echo "--- all Chrome procs:"
+          ps aux | grep -i '[C]hrome' | head -20
           set +e
           probe() {
             local label="$1"; shift

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,3 +20,41 @@ jobs:
       - run: npm ci
       - run: npm run test
       - run: npm run build
+
+  e2e:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24.x"
+          cache: "npm"
+      - run: npm ci
+      - name: Install Playwright Chrome channel
+        # E2E tests drive a real Google Chrome (channel: "chrome") via Playwright
+        # because the Chrome browser implementation relies on AppleScript/JXA
+        # which requires the real Chrome bundle (com.google.Chrome).
+        run: npx playwright install chrome
+      - name: Grant osascript AppleEvents permission for Google Chrome
+        # GitHub-hosted macOS runners have SIP disabled, so we can pre-populate
+        # TCC.db to authorize osascript -> Google Chrome. This mirrors what
+        # actions/runner-images does for Safari/Finder/SystemEvents. We specify
+        # column names explicitly since the `access` schema varies across macOS
+        # versions (macOS 14+ added pid, pid_version, boot_uuid, last_reminded).
+        run: |
+          USER_DB="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
+          SYS_DB="/Library/Application Support/com.apple.TCC/TCC.db"
+          echo "schema:"
+          sqlite3 "$USER_DB" ".schema access"
+          TS=$(date +%s)
+          SQL="INSERT OR IGNORE INTO access \
+            (service, client, client_type, auth_value, auth_reason, auth_version, \
+             indirect_object_identifier_type, indirect_object_identifier, last_modified) \
+            VALUES \
+            ('kTCCServiceAppleEvents', '/usr/bin/osascript', 1, 2, 4, 1, 0, 'com.google.Chrome', ${TS});"
+          sqlite3 "$USER_DB" "$SQL"
+          sudo sqlite3 "$SYS_DB" "$SQL"
+          echo "inserted rows:"
+          sqlite3 "$USER_DB" "SELECT service,client,indirect_object_identifier,auth_value FROM access WHERE indirect_object_identifier='com.google.Chrome';"
+          sudo sqlite3 "$SYS_DB" "SELECT service,client,indirect_object_identifier,auth_value FROM access WHERE indirect_object_identifier='com.google.Chrome';"
+      - run: npm run test:e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,12 +65,33 @@ jobs:
           launchctl kickstart -k "gui/$(id -u)/com.apple.tccd" || true
           sleep 2
       - name: Probe osascript -> Chrome before running tests
-        # Launch Chrome and run a minimal AppleScript to surface TCC/permission
-        # issues (timeout vs -1743 vs success) before Playwright tests fire.
+        # Launch Chrome and run progressively-deeper AppleScript to isolate
+        # which command hangs (TCC vs window enumeration vs JS execution).
         run: |
           open -ga "Google Chrome"
-          sleep 3
+          sleep 5
           set +e
-          osascript -e 'tell application "Google Chrome" to return name' 2>&1
-          echo "osascript exit: $?"
+          echo "--- probe 1: return name"
+          timeout 5 osascript -e 'tell application "Google Chrome" to return name' 2>&1
+          echo "exit: $?"
+          echo "--- probe 2: count windows"
+          timeout 5 osascript -e 'tell application "Google Chrome" to return count of windows' 2>&1
+          echo "exit: $?"
+          echo "--- probe 3: id of front window"
+          timeout 5 osascript -e 'tell application "Google Chrome" to return id of front window' 2>&1
+          echo "exit: $?"
+          echo "--- probe 4: every window id"
+          timeout 5 osascript -e 'tell application "Google Chrome"
+            set out to ""
+            repeat with w in (every window)
+              set out to out & (id of w) & " "
+            end repeat
+            return out
+          end tell' 2>&1
+          echo "exit: $?"
+          echo "--- probe 5: execute javascript"
+          timeout 5 osascript -e 'tell application "Google Chrome" to tell active tab of front window to execute javascript "1+1"' 2>&1
+          echo "exit: $?"
+          echo "--- ps aux for Chrome"
+          ps aux | grep -i '[C]hrome' | head -20
       - run: npm run test:e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,19 @@ jobs:
           # Register Chrome with LaunchServices before invoking by name.
           /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister \
             -f "/Applications/Google Chrome.app" || true
+          # Pre-seed Default profile with allow_javascript_apple_events=true so
+          # `execute javascript` AppleEvents are accepted without manual menu
+          # toggling (equivalent to View > Developer > Allow JavaScript from
+          # Apple Events). Chrome reads this on startup.
+          PREF_DIR="$HOME/Library/Application Support/Google/Chrome/Default"
+          mkdir -p "$PREF_DIR"
+          if [ -f "$PREF_DIR/Preferences" ]; then
+            jq '.browser.allow_javascript_apple_events = true' \
+              "$PREF_DIR/Preferences" > "$PREF_DIR/Preferences.new" \
+              && mv "$PREF_DIR/Preferences.new" "$PREF_DIR/Preferences"
+          else
+            echo '{"browser":{"allow_javascript_apple_events":true}}' > "$PREF_DIR/Preferences"
+          fi
           # Launch Chrome directly in background with a URL to force window
           # creation. 'open -a' alone starts Chrome without windows on
           # headless-ish runners.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
         # actions/runner-images does for Safari/Finder/SystemEvents. We specify
         # column names explicitly since the `access` schema varies across macOS
         # versions (macOS 14+ added pid, pid_version, boot_uuid, last_reminded).
+        # tccd caches rows at startup, so we must restart it after INSERT.
         run: |
           USER_DB="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
           SYS_DB="/Library/Application Support/com.apple.TCC/TCC.db"
@@ -57,4 +58,17 @@ jobs:
           echo "inserted rows:"
           sqlite3 "$USER_DB" "SELECT service,client,indirect_object_identifier,auth_value FROM access WHERE indirect_object_identifier='com.google.Chrome';"
           sudo sqlite3 "$SYS_DB" "SELECT service,client,indirect_object_identifier,auth_value FROM access WHERE indirect_object_identifier='com.google.Chrome';"
+          echo "restarting tccd to reload cache:"
+          sudo killall tccd || true
+          killall -u "$USER" tccd || true
+          sleep 2
+      - name: Probe osascript -> Chrome before running tests
+        # Launch Chrome and run a minimal AppleScript to surface TCC/permission
+        # issues (timeout vs -1743 vs success) before Playwright tests fire.
+        run: |
+          open -ga "Google Chrome"
+          sleep 3
+          set +e
+          osascript -e 'tell application "Google Chrome" to return name' 2>&1
+          echo "osascript exit: $?"
       - run: npm run test:e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,29 +38,31 @@ jobs:
       - name: Grant osascript AppleEvents permission for Google Chrome
         # GitHub-hosted macOS runners have SIP disabled, so we can pre-populate
         # TCC.db to authorize osascript -> Google Chrome. This mirrors what
-        # actions/runner-images does for Safari/Finder/SystemEvents. We specify
-        # column names explicitly since the `access` schema varies across macOS
-        # versions (macOS 14+ added pid, pid_version, boot_uuid, last_reminded).
-        # tccd caches rows at startup, so we must restart it after INSERT.
+        # actions/runner-images does for Safari/Finder/SystemEvents in
+        # configure-tccdb-macos.sh. macOS 15's `access` table has 17 columns;
+        # we INSERT positionally to match the schema exactly. `boot_uuid` and
+        # `last_reminded` are NOT NULL so they must be supplied. `csreq` is NULL
+        # for Apple-signed binaries like /usr/bin/osascript. tccd caches rows,
+        # so we must restart it via launchctl kickstart after INSERT.
         run: |
           USER_DB="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
           SYS_DB="/Library/Application Support/com.apple.TCC/TCC.db"
           echo "schema:"
           sqlite3 "$USER_DB" ".schema access"
-          TS=$(date +%s)
-          SQL="INSERT OR IGNORE INTO access \
-            (service, client, client_type, auth_value, auth_reason, auth_version, \
-             indirect_object_identifier_type, indirect_object_identifier, last_modified) \
-            VALUES \
-            ('kTCCServiceAppleEvents', '/usr/bin/osascript', 1, 2, 4, 1, 0, 'com.google.Chrome', ${TS});"
-          sqlite3 "$USER_DB" "$SQL"
+          SQL="INSERT OR REPLACE INTO access VALUES(
+            'kTCCServiceAppleEvents','/usr/bin/osascript',1,2,0,1,
+            NULL,NULL,0,'com.google.Chrome',
+            NULL,NULL,strftime('%s','now'),
+            NULL,NULL,'UNUSED',strftime('%s','now'));"
+          sqlite3     "$USER_DB" "$SQL"
           sudo sqlite3 "$SYS_DB" "$SQL"
-          echo "inserted rows:"
-          sqlite3 "$USER_DB" "SELECT service,client,indirect_object_identifier,auth_value FROM access WHERE indirect_object_identifier='com.google.Chrome';"
-          sudo sqlite3 "$SYS_DB" "SELECT service,client,indirect_object_identifier,auth_value FROM access WHERE indirect_object_identifier='com.google.Chrome';"
-          echo "restarting tccd to reload cache:"
-          sudo killall tccd || true
-          killall -u "$USER" tccd || true
+          echo "inserted rows (user):"
+          sqlite3     "$USER_DB" "SELECT service,client,indirect_object_identifier,auth_value,auth_reason FROM access WHERE indirect_object_identifier='com.google.Chrome';"
+          echo "inserted rows (system):"
+          sudo sqlite3 "$SYS_DB" "SELECT service,client,indirect_object_identifier,auth_value,auth_reason FROM access WHERE indirect_object_identifier='com.google.Chrome';"
+          echo "kickstarting tccd:"
+          sudo launchctl kickstart -k system/com.apple.tccd || true
+          launchctl kickstart -k "gui/$(id -u)/com.apple.tccd" || true
           sleep 2
       - name: Probe osascript -> Chrome before running tests
         # Launch Chrome and run a minimal AppleScript to surface TCC/permission

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,31 +67,35 @@ jobs:
       - name: Probe osascript -> Chrome before running tests
         # Launch Chrome and run progressively-deeper AppleScript to isolate
         # which command hangs (TCC vs window enumeration vs JS execution).
+        # macOS has no `timeout`; use AppleScript's `with timeout` instead.
         run: |
           open -ga "Google Chrome"
           sleep 5
           set +e
-          echo "--- probe 1: return name"
-          timeout 5 osascript -e 'tell application "Google Chrome" to return name' 2>&1
-          echo "exit: $?"
-          echo "--- probe 2: count windows"
-          timeout 5 osascript -e 'tell application "Google Chrome" to return count of windows' 2>&1
-          echo "exit: $?"
-          echo "--- probe 3: id of front window"
-          timeout 5 osascript -e 'tell application "Google Chrome" to return id of front window' 2>&1
-          echo "exit: $?"
-          echo "--- probe 4: every window id"
-          timeout 5 osascript -e 'tell application "Google Chrome"
-            set out to ""
-            repeat with w in (every window)
-              set out to out & (id of w) & " "
-            end repeat
-            return out
-          end tell' 2>&1
-          echo "exit: $?"
-          echo "--- probe 5: execute javascript"
-          timeout 5 osascript -e 'tell application "Google Chrome" to tell active tab of front window to execute javascript "1+1"' 2>&1
-          echo "exit: $?"
+          probe() {
+            local label="$1"; shift
+            echo "--- ${label}"
+            osascript -e "with timeout of 4 seconds
+              $*
+            end timeout" 2>&1
+            echo "exit: $?"
+          }
+          probe "probe 1: return name" \
+            'tell application "Google Chrome" to return name'
+          probe "probe 2: count windows" \
+            'tell application "Google Chrome" to return count of windows'
+          probe "probe 3: id of front window" \
+            'tell application "Google Chrome" to return id of front window'
+          probe "probe 4: every window id" \
+            'tell application "Google Chrome"
+               set out to ""
+               repeat with w in (every window)
+                 set out to out & (id of w) & " "
+               end repeat
+               return out
+             end tell'
+          probe "probe 5: execute javascript" \
+            'tell application "Google Chrome" to tell active tab of front window to execute javascript "1+1"'
           echo "--- ps aux for Chrome"
-          ps aux | grep -i '[C]hrome' | head -20
+          ps aux | grep -i '[C]hrome' | grep -v Helper | head -10
       - run: npm run test:e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,10 @@ jobs:
         # a window (CI runners without a logged-in GUI may otherwise launch
         # Chrome with no windows, making window-querying AppleEvents hang).
         run: |
-          open -a "Google Chrome" "https://example.com"
+          # Register Chrome with LaunchServices before invoking by name.
+          /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister \
+            -f "/Applications/Google Chrome.app" || true
+          open -a "/Applications/Google Chrome.app" "https://example.com"
           sleep 5
           set +e
           probe() {


### PR DESCRIPTION
## Summary

- GitHub Actions macOS runner で E2E (Playwright) テストを実行する試み
- `actions/runner-images` 同様、SIP 無効な runner 上で `TCC.db` に `osascript → com.google.Chrome` の AppleEvents 許可を事前 INSERT し、Automation ダイアログを回避

## Context

過去 72bb705 で CI での E2E 実行を諦めた経緯あり。TCC 事前付与の手段が現実的に成立するか検証するため、このブランチは main から workflow 変更のみを切り出した。

ブラウザ実装 (AppleScript のまま) は main と同一。CI 側の挙動のみ検証。

## Test plan

- [ ] GitHub Actions の `e2e` job が TCC INSERT step で成功する
- [ ] `npm run test:e2e` が 4 ケースすべて pass する