### PR TITLE
feat: support 2026-07-28 protocol revision via serveStdio

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -160,8 +160,8 @@ async function main(): Promise<void> {
     showHelp();
     process.exit(0);
   }
-  // serveStdio pins one instance per connection and selects the protocol era
-  // from the opening exchange, serving both 2025-era and 2026-07-28 clients.
+  // serveStdio picks the protocol era from the opening exchange, so the same
+  // factory serves both 2025-era and 2026-07-28 clients
   const handle = serveStdio(() => createMcpServer(options));
 
   const shutdown = async () => {
@@ -170,6 +170,9 @@ async function main(): Promise<void> {
   };
   process.on("SIGINT", shutdown);
   process.on("SIGTERM", shutdown);
+  // StdioServerTransport only watches stdin "data" and "error", so EOF never
+  // reaches the server on its own
+  process.stdin.on("end", shutdown);
 }
 
 await main().catch(console.error);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { parseArgs } from "util";
-import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
 import { createMcpServer, McpServerOptions, packageVersion } from "./mcp.js";
 import type { Browser } from "./browser/browser.js";
 
@@ -160,13 +160,12 @@ async function main(): Promise<void> {
     showHelp();
     process.exit(0);
   }
-  const server = await createMcpServer(options);
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+  // serveStdio pins one instance per connection and selects the protocol era
+  // from the opening exchange, serving both 2025-era and 2026-07-28 clients.
+  const handle = serveStdio(() => createMcpServer(options));
 
   const shutdown = async () => {
-    await transport.close();
-    await server.close();
+    await handle.close();
     process.exit(0);
   };
   process.on("SIGINT", shutdown);

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -271,6 +271,7 @@ export async function createMcpServer(
 
   if (options.checkInterval > 0) {
     let lastHash: string = hashTabList(await listTabs(options));
+    let stopped = false;
     const check = async () => {
       try {
         const hash = hashTabList(await listTabs(options));
@@ -281,10 +282,19 @@ export async function createMcpServer(
       } catch (error) {
         console.error("Error during periodic tab list update:", error);
       }
+      // The connection may have closed while the AppleScript call was in flight
+      if (stopped) return;
       // Use setTimeout instead of setInterval to avoid overlapping calls
-      setTimeout(check, options.checkInterval);
+      timer = setTimeout(check, options.checkInterval);
     };
-    check();
+    // Wait one interval, otherwise the first tick polls right after the snapshot above
+    let timer = setTimeout(check, options.checkInterval);
+    // serveStdio builds one instance per connection, so the poller has to stop
+    // with the instance
+    server.server.onclose = () => {
+      stopped = true;
+      clearTimeout(timer);
+    };
   }
 
   return server;


### PR DESCRIPTION
## Summary

- Adopt `serveStdio()` so the server can speak the 2026-07-28 protocol revision
- Existing 2025-era clients keep working unchanged — the same factory serves both eras
- Fix a pre-existing leak in the `--check-interval` poller, which `serveStdio` makes worse

Follows up #156, which moved to the SDK v2 packages but deliberately left the protocol revision at 2025-11-25. `serveStdio` is the stdio entry point that owns the era decision, and it only exists in v2.

## Changes

### Protocol revision (`src/cli.ts`)

```diff
-const server = await createMcpServer(options);
-const transport = new StdioServerTransport();
-await server.connect(transport);
+const handle = serveStdio(() => createMcpServer(options));
```

`serveStdio` takes a factory, pins one server instance per connection, and selects the era from the opening exchange: an `initialize` request pins the 2025 era, a modern opening pins 2026-07-28. Legacy handling defaults to `'serve'` (not `'reject'`), so existing clients are unaffected. Shutdown now goes through the returned handle's `close()` instead of closing the transport and server separately.

The protocol surface needed nothing else. This server is read-only and holds no session state, which is what most of the 2026-07-28 breaking changes are about:

- It does not use sampling, elicitation, roots, or logging, so the MRTR migration does not apply
- It never reads `getClientCapabilities()` / `getClientVersion()`, which return `undefined` on 2026-era connections
- `sendResourceListChanged()` (used when `--check-interval` > 0) is routed onto 2026-era `subscriptions/listen` streams by `serveStdio` automatically
- The remaining breaking changes (sessions, `Mcp-Session-Id`, SSE resumability, `Mcp-Param-*` headers, OAuth) are all HTTP-specific

### Poller lifecycle (`src/cli.ts`, `src/mcp.ts`)

The notification *routing* above is handled by the SDK, but the poller's *lifecycle* was not. The `--check-interval` loop re-armed itself with `setTimeout` forever, with no stop condition, so the process outlived the client:

| | result |
| --- | --- |
| before, `--check-interval=500`, stdin closed | process never exits |
| before, `--check-interval=0` (default) | exits cleanly |
| after, `--check-interval=500`, stdin closed | exits cleanly |

The leak predates this PR and only shows up when `--check-interval` is enabled, which is off by default. It matters more under `serveStdio` because the factory runs once per connection, so every connection would start another poller that nothing stops.

Two parts to the fix, because the obvious half is not enough:

- `src/mcp.ts` stops the loop from `server.server.onclose` (`Protocol.onclose`, which also fires on `close()`). The `stopped` flag is checked on both sides of the await so a tick already in flight cannot re-arm after close.
- `src/cli.ts` adds `process.stdin.on("end", shutdown)`. `StdioServerTransport` only listens for `"data"` and `"error"` on stdin, so a plain client disconnect (EOF) never reaches the server and `onclose` alone would never fire for the most common exit path.

Also defers the first tick by one interval. The loop previously called `check()` immediately after taking the initial hash snapshot, hitting AppleScript twice back to back at startup.

## Confirmed

- `npm run build` (tsc) succeeds
- `npm test` passes (4 files, 33 tests)
- `npm run test:e2e` passes (4 tests, real Chrome)
- `npx prettier --check` is clean on the changed files
- Connected the SDK `Client` over stdio against `dist/cli.js` in both negotiation modes:
  - `versionNegotiation: { mode: 'legacy' }` → `era=legacy`, all three tools listed
  - `versionNegotiation: { mode: { pin: '2026-07-28' } }` → `era=modern`, all three tools listed
- `--check-interval=500` exits 0 both on immediate stdin EOF and on EOF after an `initialize` (it used to hang)
- Polling keeps running while connected: 3 ticks over 5s at `--check-interval=500`, which matches the measured 750ms AppleScript round-trip per cycle
- Notifications still fire: connected with `--check-interval=800`, opened a tab, received `notifications/resources/list_changed`, and `tools/list` still answered afterwards

## Note on testing

No test changes. `tests/mcp.test.ts` covers what `createMcpServer()` registers — tool behavior, excluded-host filtering, resource contents — and the era a connection negotiates does not change what that factory builds, so those tests stay valid as-is.

What is genuinely new is the wiring in `src/cli.ts`: that `serveStdio` starts up and accepts both eras, and that the poller stops with the connection. That was verified manually against the built `dist/cli.js` (see above) rather than in the suite, since covering it automatically means spawning the CLI as a child process and timing a poll loop.
