### PR TITLE
fix(browser): switch Chrome control to JXA to fix process selection with multiple instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Model Context Protocol (MCP) server that provides direct access to your browser'
 ## Requirements
 
 > [!IMPORTANT]  
-> **macOS only** - This MCP server uses AppleScript and only works on macOS.
+> **macOS only** - This MCP server uses Apple Events (JXA/AppleScript) and only works on macOS.
 
 - **Node.js** 20 or newer
 - **MCP Client** such as Claude Desktop, Claude Code, or any MCP-compatible client
-- **macOS** only (uses AppleScript for browser automation)
+- **macOS** only (uses Apple Events via JXA/AppleScript for browser automation)
 
 ## Getting Started
 
@@ -30,6 +30,8 @@ First, enable "Allow JavaScript from Apple Events" in Chrome:
 - (ja) **表示** > **開発 / 管理** > **Apple Events からの JavaScript を許可**
 
 When you first use the MCP server, macOS will prompt you to grant AppleScript automation permission to your MCP client (e.g., Claude Desktop, Claude Code). Click **OK** to allow access to Chrome. If you accidentally dismissed the dialog, you can enable it in **System Settings** > **Privacy & Security** > **Automation**.
+
+When multiple Google Chrome processes exist, JXA generally selects the oldest process, but this is not a guaranteed process-selection API. Start your normal Chrome before starting other Chrome instances when process identity matters.
 
 Standard config works in most MCP clients (e.g., `.claude.json`, `.mcp.json`):
 
@@ -67,18 +69,22 @@ You can also install this as a Claude Code plugin:
 The server accepts optional command line arguments for configuration:
 
 **Content Extraction Options**
+
 - `--max-content-chars` - Maximum content characters per single read (default: 20000)
 - `--extraction-timeout` - Timeout for content extraction worker in milliseconds (default: 20000)
 - `--exclude-hosts` - Comma-separated list of domains to exclude from tab listing and content access
 
 **Resource Options**
+
 - `--check-interval` - Interval in milliseconds to check for tab changes and send listChanged notifications (default: 0 disabled, set to 3000 for 3 seconds)
 
 **Browser Options**
+
 - `--application-name` - Application name to control (default: "Google Chrome")
 - `--experimental-browser` - Browser implementation to use: "chrome", "safari", or "arc" (default: "chrome")
 
 **Other Options**
+
 - `--help` - Show help message with all available options
 
 ### Resource Subscription (Optional)

--- a/docs/jxa-migration.md
+++ b/docs/jxa-migration.md
@@ -1,178 +1,70 @@
-# JXA への全面移行ガイド
+# JXA 移行ガイド
 
-`src/browser/{chrome,safari,arc}.ts` を AppleScript から JXA (osascript -l JavaScript) に移行するための作業メモ。Chrome は `fix-multi-chrome-instance` ブランチで先行実施済み。Safari と Arc は未着手。
+この文書は、ブラウザー操作を AppleScript から JXA（`osascript -l JavaScript`）へ移行する際の設計と確認事項をまとめたものです。現在、Chrome の実装だけが JXA を使用し、Safari と Arc は AppleScript のままです。
 
-## なぜ JXA に移行するのか
+## Chrome で JXA を採用した理由
 
-### 直接の動機: Chrome の複数インスタンス問題
+同じ bundle ID（`com.google.Chrome`）を持つプロセスが複数あると、AppleScript の `tell application "Google Chrome"` は新しく起動したプロセスを選択することがあります。別ツールが起動した headless Chrome が後から選択されると、ユーザーが操作している Chrome に Apple Event が届きません。
 
-`tell application "Google Chrome"` は同一 bundle id (`com.google.Chrome`) のプロセスが複数あるとき **最新起動プロセス** を掴む。Playwright MCP のような別ツールが headless Chrome を後から起動すると、ユーザーの本来の Chrome ではなく headless 側に Apple Event が届いてしまう。
+JXA の `Application("Google Chrome")` は、複数プロセスがある場合に最も古く起動したプロセスを選択する挙動が経験的に観測されています。この挙動は公式 API ではなく、起動順に依存するヒューリスティックです。対象の Chrome より先に別プロセスが起動している場合は、そのプロセスが選択される可能性があります。
 
-JXA の `Application("Google Chrome")` は逆に **最古起動プロセス** を掴むため、ユーザーの Chrome を先に起動しておけば確実に本物に届く (deanishe.net の経験的観測。Apple 公式ドキュメントには記載なし)。
+PID を指定して Apple Event の送信先を確実に固定する公式 API は、`NSAppleEventDescriptor descriptorWithProcessIdentifier:` や `SBApplication applicationWithProcessIdentifier:` などの Objective-C bridge を必要とします。このプロジェクトでは、JXA から Chrome の sdef を解決できなくなる制約があるため採用していません。
 
-PID 指定で特定のプロセスを狙う公式 API (`NSAppleEventDescriptor descriptorWithProcessIdentifier:` / `SBApplication applicationWithProcessIdentifier:`) は ObjC bridge が必要で、JXA からだと Chrome の sdef 解決に失敗するので採用していない。
+JXA には、次の実装上の利点もあります。
 
-### 二次的なメリット (Safari/Arc にも効く)
+- タブ一覧や内容を JSON で受け渡せるため、区切り文字を本文から除外する必要がない。
+- `String(w.id())` のように ID の型を明示できる。
+- AppleScript の `tell` / `repeat` の入れ子が減り、処理の対応関係を追いやすい。
+- JavaScript の `try` / `catch` でエラー処理を書ける。
 
-1. **JSON でデータをやり取りできる** — AppleScript はカスタムセパレータ文字列 (`<|SEP:xxx|>`) でフィールドを連結する必要があり、本文中にセパレータが現れた場合の分離が脆弱。JXA なら `JSON.stringify` / `JSON.parse` で安全に往復できる。
-2. **値の型が明示的** — AppleScript の `id of aWindow` は number か string か曖昧 (Arc は UUID で string、Chrome は number)。JXA なら `String(w.id())` で確定できる。
-3. **コード量が減る** — `repeat with ... in ...` / `tell ... end tell` のネストが消えて、見通しが良くなる。
-4. **エラーハンドリングが try/catch で書ける** — AppleScript の `try ... on error` ブロックが消える。
+## ブラウザーごとの ID と API
 
-## 既存の AppleScript 実装の差分ポイント (browser ごと)
+| 項目            | Chrome（JXA）                           | Safari（AppleScript）               | Arc（AppleScript）   |
+| --------------- | --------------------------------------- | ----------------------------------- | -------------------- |
+| Window ID       | 数値を文字列化                          | 数値を文字列化                      | UUID 文字列          |
+| Tab ID          | 数値を文字列化                          | 固有 ID はなく、タブの index を使用 | UUID 文字列          |
+| 現在のタブ      | `activeTab()`                           | `current tab`                       | `active tab`         |
+| JavaScript 実行 | `app.execute(tab, { javascript: ... })` | `do JavaScript`                     | `execute javascript` |
 
-| 項目 | Chrome (移行済) | Safari | Arc |
-|---|---|---|---|
-| Window ID | number | number | UUID (string) |
-| Tab ID | number | **存在しない** (index で代用) | UUID (string) |
-| 現在のタブ | `active tab of window` | `current tab of window` | `active tab of window` |
-| JS 実行 | `execute javascript` | `do JavaScript` | `execute javascript` (戻り値が `"..."` でラップされ `\uXXXX` でエスケープされている可能性あり) |
-| Allow JS from AppleEvents 設定 | View > Developer 必須 | Develop メニュー > Allow JavaScript from Apple Events | 同左 |
+Safari の `tabId` はタブの位置を表す値です。タブを閉じると後続タブの index が変わるため、取得済みの `TabRef` が別のタブを指す可能性があります。Safari の window には ID がありますが、tab には Chrome や Arc のような固有 ID がありません。このため、Safari では Chrome のような `tabs.byId(...)` による参照はできず、index で参照します。
 
-### Safari の固有問題
+Arc の window と tab は UUID です。active tab を直接操作する方法は環境によって失敗するため、現在の実装は先に front window と active tab の ID を解決し、ID 指定で操作します。`make new tab` の戻り値から tab ID を取得できないため、新規タブの参照には active tab の ID を使っています。Arc の `execute javascript` の戻り値は文字列としてラップまたはエスケープされる場合があり、AppleScript 実装は必要に応じて `JSON.parse` で復元します。JXA 版で同じ API を使う場合の戻り値形式は未検証です。
 
-- **Tab に unique id が無い** ので `tabId = index` で代用している。タブを閉じると後続タブの index が変わって参照が壊れる (README にも明記)。JXA に移行しても解消しない既存問題。
-- AppleScript の `tab N` (index 指定) は JXA だと `window.tabs[index - 1]` (0-origin) になる。
+## 移行時の実装方針
 
-### Arc の固有問題
+Chrome の JXA は、window と tab を走査して `{ windowId, tabId, title, url }` の配列を作り、`JSON.stringify` で返します。TypeScript 側で `JSON.parse` して `Tab[]` に変換します。アプリケーション名は JSON 文字列リテラルとして JXA に埋め込み、入力値によるスクリプト構文の破壊を防ぎます。
 
-- `make new tab` の戻り値オブジェクトから `id` を取れない。AppleScript 版は `id of (active tab)` で代用している。JXA も同じ workaround が必要。
-- `execute javascript` の戻り値が `"..."` でラップされているケースがあり、`JSON.parse` でデコードしている。JXA だと `app.execute(t, {javascript: "..."})` の戻り値が string として返るので、同じ後処理 (string が `"..."` で囲まれていたら JSON.parse) が必要かは要検証。
+Chrome では `app.windows.byId(Number(windowId))` と `win.tabs.byId(Number(tabId))` を使います。Safari では window ID を使って window を検索し、tab は 1-origin の index を 0-origin の配列位置に変換して参照します。Arc では window と tab の UUID を文字列のまま扱います。
 
-## Chrome JXA 化での具体的な書き換えパターン
+Safari の JXA で `do JavaScript` を呼ぶ形式（たとえば `app.doJavaScript(script, { in: tab })`）は、sdef に基づく候補であり、実ブラウザーでの確認が必要です。
 
-### Before (AppleScript)
+JXA には AppleScript の `with timeout` に相当する構文がありません。通常の JXA 実行は `osascript.ts` の `execFile` timeout（既定 5 秒）とリトライで保護します。Chrome のページ内容取得は suspended tab で停止する可能性があるため、timeout を 3 秒、`maxRetries` を 0 とし、同じ Apple Event を再送しません。timeout になると `osascript` プロセスを終了し、呼び出し元へエラーを返します。Safari と Arc を移行する場合は、ブラウザーごとの停止条件を確認してから設定を決めます。
 
-```typescript
-const sep = separator();
-const appleScript = `
-  tell application "${applicationName}"
-    set output to ""
-    repeat with aWindow in (every window)
-      set windowId to id of aWindow
-      repeat with aTab in (every tab of aWindow)
-        set tabId to id of aTab
-        set tabTitle to title of aTab
-        set tabURL to URL of aTab
-        set output to output & windowId & "${sep}" & tabId & ...
-      end repeat
-    end repeat
-    return output
-  end tell
-`;
-const result = await executeAppleScript(appleScript);
-const lines = result.trim().split("\n");
-for (const line of lines) {
-  const [wId, tId, title, url] = line.split(sep);
-  // ...
-}
+JXA の実行エラーと JSON の解析エラーは TypeScript 側で処理します。ブラウザー固有の分岐が増える場合は、JXA 内の `try` / `catch` でブラウザー API のエラーを構造化して返す方法も検討できます。
+
+## Safari と Arc の移行候補
+
+Safari と Arc の移行は未実施です。移行する場合は、タブ一覧の ID 変換、指定タブと現在のタブの解決、新規タブ作成後の参照、JavaScript 実行の戻り値と timeout を、ブラウザーごとに実ブラウザーで確認します。Safari は tab index の変動、Arc は active tab ID を使う現行 workaround の妥当性を確認します。
+
+全ブラウザーの移行が完了し、呼び出し元がなくなった場合に限り、`executeAppleScript`、`escapeAppleScript`、`separator` の削除を検討します。
+
+## テスト
+
+E2E は Chrome のみを対象とします。Playwright の Chromium が必要なため、初回は `npx playwright install chromium` を実行します。テストは `playwright.chromium.executablePath()` で取得した bundled Chromium を専用の永続プロファイルで起動し、その `.app` の絶対パスを JXA の application name として渡します。通常の Google Chrome（`com.google.Chrome`）は起動したままで構いません。テスト用ブラウザーは別 bundle（`Google Chrome for Testing.app` / `com.google.chrome.for.testing`）です。
+
+起動前にテスト用実行ファイルを `pgrep -x` で確認します。既に起動中ならテストは失敗しますが、プロセスを終了させません。起動後は専用 URL の一意な marker が Playwright の context と `getTabList` の両方から見えることを確認し、対象プロセスが不明な場合は操作を中止します。
+
+専用プロファイルの [`Default/Preferences`](../tests/integration/chrome-profile/Default/Preferences) には、Apple Events からの JavaScript 実行を許可する `browser.allow_javascript_apple_events=true` が記録されています。通常実行、画面表示、デバッグ実行は次のコマンドで行います。
+
+```bash
+npm run test:e2e
+npm run test:e2e -- --headed
+npm run test:e2e -- --debug
 ```
 
-### After (JXA)
+Chrome のユニットテスト（`tests/chrome.test.ts`）は JXA の `Application` を vm 内のモックに差し替えてスクリプトの結果を検証します。実際の JXA や Chrome は起動しません。そのため、Safari と Arc の移行後は macOS 上の実ブラウザーで別途確認が必要です。
 
-```typescript
-const script = `
-  const app = Application(${jsonStringLiteral(applicationName)});
-  const out = [];
-  for (const w of app.windows()) {
-    const windowId = String(w.id());
-    for (const t of w.tabs()) {
-      out.push({
-        windowId,
-        tabId: String(t.id()),
-        title: t.title(),
-        url: t.url(),
-      });
-    }
-  }
-  JSON.stringify(out);
-`;
-const result = await executeJXA(script);
-const parsed = JSON.parse(result) as Tab[];
-```
+## 設計上の参考情報
 
-ポイント:
-- セパレータは不要 (JSON.stringify で往復)
-- `(every tab of aWindow)` → `w.tabs()` (関数呼び出し)
-- `id of aWindow` → `w.id()` (関数呼び出し)
-- 文字列リテラルは `jsonStringLiteral()` で JS 文字列リテラルに埋め込み (escape は JSON.stringify が担う)
-
-### Tab ID 指定での参照
-
-AppleScript:
-```applescript
-tell window id "${windowId}"
-  tell tab id "${tabId}"
-    ...
-  end tell
-end tell
-```
-
-JXA:
-```javascript
-const win = app.windows.byId(Number(windowId));
-const tab = win.tabs.byId(Number(tabId));
-```
-
-Safari の場合は `byId` が使えないので `win.tabs[index - 1]` (index は 1-origin で渡されてくるので -1 する) になる見込み。
-
-### `with timeout` の代替
-
-AppleScript の `with timeout of N seconds ... end timeout` は JXA で表現できない。Chrome 版では諦めて、osascript の execFile timeout (`osascript.ts` の 5 秒) と `retry` wrapper でカバーしている。
-
-```typescript
-// osascript.ts
-export async function executeJXA(script: string): Promise<string> {
-  return retry(async () => {
-    const { stdout, stderr } = await execFileAsync(
-      "osascript",
-      ["-l", "JavaScript", "-e", script],
-      { timeout: 5 * 1000, maxBuffer: 10 * 1024 * 1024 }
-    );
-    if (stderr) console.error("JXA stderr:", stderr);
-    return stdout.trim();
-  });
-}
-```
-
-suspended tab で `execute javascript` がハングするケースは、osascript プロセスごと SIGTERM されてリトライに任せる方針。
-
-### エラーハンドリング
-
-AppleScript の `try ... on error errMsg` は JXA の `try { ... } catch (e) { ... }` で書ける。Chrome 版では JXA 内 try は使わず、外側 (TypeScript) で `JSON.parse` の失敗を見て対応している。Safari/Arc のように分岐の多い処理 (active tab 取得など) は JXA 内 try/catch を使うほうが読みやすい場合がある。
-
-## 移行作業のステップ案
-
-1. **Safari**
-   - `getSafariTabList` を JXA で書き直す (Tab に id がないので `tabId: String(index + 1)` を保持)
-   - `getPageContent`: `app.windows.byId(...)` の Safari 版相当 (`app.windows.whose({id: ...})[0]` か `for` ループでマッチング) を確認
-   - `openURL`: `app.Tab({url: ...})` で新規 tab を作って `front_window.tabs.push(newTab)`
-   - `do JavaScript` は JXA だと `app.doJavaScript("...", {in: tab})` の形になる (Safari の sdef に準拠)
-
-2. **Arc**
-   - Chrome とほぼ同じ構造。`execute javascript` の戻り値ラップ問題は AppleScript 版と同じ後処理を保持
-   - `make new tab` の id 取得不可問題は `app.windows[0].activeTab().id()` で代用
-
-3. **executeAppleScript の削除可否**
-   - 全 browser を JXA 化したら `executeAppleScript` / `escapeAppleScript` / `separator` は不要になる可能性がある。`osascript.ts` から削除して問題ないか確認
-
-## テスト戦略
-
-- e2e (Playwright) は Chrome のみ対象なので、Safari/Arc の JXA 化は **手動確認**しかない
-- ローカルで以下を確認:
-  1. `npm run dev` で MCP server 起動 → Claude Code 等から `list_tabs` / `read_tab_content` / `open_in_new_tab` を順に呼んで結果が AppleScript 版と一致するか
-  2. 複数 window を開いて全 tab が列挙されるか
-  3. JS が実行できるか (タブ内容が取れるか)
-  4. 新規 tab を開いた直後にその tab の content が読めるか (TabRef がすぐ使えるか)
-
-## 参考
-
-- Chrome 移行のコミット: `c43be9d` (`fix-multi-chrome-instance` ブランチ)
-- JXA で複数インスタンスのうち最古を掴む挙動: https://www.deanishe.net/snippet/multiple-app-instances/
-- CI 上で AppleScript/JXA テストが動かなかった経緯: PR #131 のコメント
-
-## このドキュメントを書いた時点の状態
-
-- branch `fix-multi-chrome-instance`: Chrome 移行済み、main にマージ前 (PR 未作成)
-- branch `ci-enable-e2e`: PR #131 として close 済み (hosted runner で AppleScript ベース e2e は動かないと結論)
-- Safari/Arc の JXA 化は未着手
+- 複数のアプリケーションプロセスを扱う JXA の挙動については、[deanishe.net の調査](https://www.deanishe.net/snippet/multiple-app-instances/)を参照してください。プロセス選択の公式仕様ではありません。
+- AppleScript/JXA をホストされた CI runner で実行できない環境があるため、E2E は Apple Events を利用できる macOS 環境で実行します。

--- a/docs/jxa-migration.md
+++ b/docs/jxa-migration.md
@@ -38,7 +38,11 @@ Chrome では `app.windows.byId(Number(windowId))` と `win.tabs.byId(Number(tab
 
 Safari の JXA で `do JavaScript` を呼ぶ形式（たとえば `app.doJavaScript(script, { in: tab })`）は、sdef に基づく候補であり、実ブラウザーでの確認が必要です。
 
-JXA には AppleScript の `with timeout` に相当する構文がありません。通常の JXA 実行は `osascript.ts` の `execFile` timeout（既定 5 秒）とリトライで保護します。Chrome のページ内容取得は suspended tab で停止する可能性があるため、timeout を 3 秒、`maxRetries` を 0 とし、同じ Apple Event を再送しません。timeout になると `osascript` プロセスを終了し、呼び出し元へエラーを返します。Safari と Arc を移行する場合は、ブラウザーごとの停止条件を確認してから設定を決めます。
+JXA には AppleScript の `with timeout` に相当する構文がありません。通常の JXA 実行は `osascript.ts` の `execFile` timeout（既定 5 秒）とリトライで保護します。Chrome のページ内容取得は suspended tab で停止する可能性があるため、timeout を 3 秒、`maxRetries` を 0 とし、同じ Apple Event を再送しません。timeout になると `osascript` プロセスを終了し、呼び出し元へエラーを返します。
+
+AppleScript の `with timeout` は Apple Event の応答待ちだけを制限しますが、`execFile` の timeout は `osascript` プロセス全体を制限します。この差により、スクリプトの起動やタブの走査も 3 秒の予算に含まれます。20 タブの実測では、`osascript` の起動が 40〜50ms、正常なタブの `execute javascript` が 124〜225ms でした。所要時間は DOM のサイズにほとんど依存せず、5MB の Gmail でも 216ms です。一方 suspended tab は 10 秒でも応答しません。正常応答とハングの二分が明確で中間の分布がないため、3 秒はどちらの側にも十分な余裕があります。timeout を延ばしても救えるタブはなく、ハング時の待ち時間が伸びるだけです。
+
+Safari と Arc を移行する場合は、ブラウザーごとの停止条件を確認してから設定を決めます。
 
 JXA の実行エラーと JSON の解析エラーは TypeScript 側で処理します。ブラウザー固有の分岐が増える場合は、JXA 内の `try` / `catch` でブラウザー API のエラーを構造化して返す方法も検討できます。
 

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -1,128 +1,101 @@
 import type { BrowserInterface, TabRef, Tab, TabContent } from "./browser.js";
-import {
-  escapeAppleScript,
-  executeAppleScript,
-  separator,
-} from "./osascript.js";
+import { executeJXA } from "./osascript.js";
+
+/*
+Why JXA instead of AppleScript:
+
+When multiple processes share the same bundle id (e.g., the user's Google Chrome
+and a headless Chrome launched by Playwright MCP), AppleScript's
+`tell application "Google Chrome"` resolves to the newest-launched process,
+which may not be the user's foreground Chrome.
+
+JXA's `Application("Google Chrome")` resolves to the oldest-launched process
+instead, which reliably points to the user's primary Chrome in the common case.
+There is no public API to target a specific PID without ObjC bridging, so we
+rely on this JXA behavior documented at https://www.deanishe.net/snippet/multiple-app-instances/
+*/
+
+function jsonStringLiteral(value: string): string {
+  return JSON.stringify(value);
+}
 
 async function getChromeTabList(applicationName: string): Promise<Tab[]> {
-  const sep = separator();
-  const appleScript = `
-    tell application "${applicationName}"
-      set output to ""
-      repeat with aWindow in (every window)
-        set windowId to id of aWindow
-        repeat with aTab in (every tab of aWindow)
-          set tabId to id of aTab
-          set tabTitle to title of aTab
-          set tabURL to URL of aTab
-          set output to output & windowId & "${sep}" & tabId & "${sep}" & tabTitle & "${sep}" & tabURL & "\\n"
-        end repeat
-      end repeat
-      return output
-    end tell
+  const script = `
+    const app = Application(${jsonStringLiteral(applicationName)});
+    const out = [];
+    for (const w of app.windows()) {
+      const windowId = String(w.id());
+      for (const t of w.tabs()) {
+        out.push({
+          windowId,
+          tabId: String(t.id()),
+          title: t.title(),
+          url: t.url(),
+        });
+      }
+    }
+    JSON.stringify(out);
   `;
 
-  const result = await executeAppleScript(appleScript);
-  const lines = result.trim().split("\n");
-  const tabs: Tab[] = [];
-  for (const line of lines) {
-    const [wId, tId, title, url] = line.split(sep);
-    if (!/^https?:\/\//.test(url)) continue;
-
-    tabs.push({
-      windowId: wId,
-      tabId: tId,
-      title: title.trim(),
-      url: url.trim(),
-    });
-  }
-  return tabs;
+  const result = await executeJXA(script);
+  const parsed = JSON.parse(result) as Tab[];
+  return parsed.filter((t) => /^https?:\/\//.test(t.url));
 }
 
 async function getPageContent(
   applicationName: string,
   tab?: TabRef | null
 ): Promise<TabContent> {
-  const sep = separator();
-  const inner = `
-    set tabTitle to title
-    set tabURL to URL
-    set tabContent to execute javascript "document.documentElement.outerHTML"
-    return tabTitle & "${sep}" & tabURL & "${sep}" & tabContent
+  const script = `
+    const app = Application(${jsonStringLiteral(applicationName)});
+    const target = ${tab ? jsonStringLiteral(JSON.stringify(tab)) : "null"};
+
+    // Chrome's "execute javascript" may hang on suspended tabs. JXA cannot
+    // express AppleScript's "with timeout" block, so we rely on osascript's
+    // outer process timeout and the retry wrapper.
+    let targetTab;
+    if (target) {
+      const t = JSON.parse(target);
+      const win = app.windows.byId(Number(t.windowId));
+      targetTab = win.tabs.byId(Number(t.tabId));
+    } else {
+      for (const w of app.windows()) {
+        const t = w.activeTab();
+        if (t.url() !== "about:blank") {
+          targetTab = t;
+          break;
+        }
+      }
+      if (!targetTab) throw new Error("No active tab found");
+    }
+
+    const result = {
+      title: targetTab.title(),
+      url: targetTab.url(),
+      content: app.execute(targetTab, { javascript: "document.documentElement.outerHTML" }),
+    };
+    JSON.stringify(result);
   `;
-  const appleScript = tab
-    ? `
-      try
-        tell application "${applicationName}"
-          tell window id "${tab.windowId}"
-            tell tab id "${tab.tabId}"
-              (* Chrome によって suspend されたタブで js を実行すると動作が停止する
-                 タイムアウトにより osascript コマンドの実行を retry したくないので
-                 apple script 内で timeout をしてエラーを返すようにする *)
-              with timeout of 3 seconds
-                ${inner}
-              end timeout
-            end tell
-          end tell
-        end tell
-      on error errMsg
-        return "ERROR" & "${sep}" & errMsg
-      end try
-    `
-    : `
-      try
-        tell application "${applicationName}"
-          repeat with w in windows
-            tell w
-              set t to tab (active tab index)
-              if URL of t is not "about:blank" then
-                tell t
-                  ${inner}
-                end tell
-              end if
-            end tell
-          end repeat
-          error "No active tab found"
-        end tell
-      on error errMsg
-        return "ERROR" & "${sep}" & errMsg
-      end try
-    `;
 
-  const scriptResult = await executeAppleScript(appleScript);
-  if (scriptResult.startsWith(`ERROR${sep}`)) {
-    throw new Error(scriptResult.split(sep)[1]);
-  }
-
-  const parts = scriptResult.split(sep).map((part) => part.trim());
-  if (parts.length < 3) {
-    throw new Error("Failed to read the tab content");
-  }
-
-  const [title, url, content] = parts;
-
-  return {
-    title,
-    url,
-    content,
-  };
+  const scriptResult = await executeJXA(script);
+  const parsed = JSON.parse(scriptResult) as TabContent;
+  return parsed;
 }
 
 async function openURL(applicationName: string, url: string): Promise<TabRef> {
-  const escapedUrl = escapeAppleScript(url);
-  const sep = separator();
-  const appleScript = `
-    tell application "${applicationName}"
-      set newTab to (make new tab at end of tabs of front window with properties {URL:"${escapedUrl}"})
-      set windowId to id of front window
-      set tabId to id of newTab
-      return windowId & "${sep}" & tabId
-    end tell
+  const script = `
+    const app = Application(${jsonStringLiteral(applicationName)});
+    const win = app.windows[0];
+    const newTab = app.Tab({ url: ${jsonStringLiteral(url)} });
+    win.tabs.push(newTab);
+    JSON.stringify({
+      windowId: String(win.id()),
+      tabId: String(newTab.id()),
+    });
   `;
-  const result = await executeAppleScript(appleScript);
-  const [windowId, tabId] = result.trim().split(sep);
-  return { windowId, tabId };
+
+  const result = await executeJXA(script);
+  return JSON.parse(result) as TabRef;
 }
 
 export const chromeBrowser: BrowserInterface = {

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -17,13 +17,15 @@ bridging, so we rely on this behavior documented at
 https://www.deanishe.net/snippet/multiple-app-instances/
 */
 
-function jsonStringLiteral(value: string): string {
+// Embeds a value into the JXA source as a JSON literal, so that user input
+// cannot break out of the surrounding script syntax.
+function jsonLiteral(value: unknown): string {
   return JSON.stringify(value);
 }
 
 async function getChromeTabList(applicationName: string): Promise<Tab[]> {
   const script = `
-    const app = Application(${jsonStringLiteral(applicationName)});
+    const app = Application(${jsonLiteral(applicationName)});
     const out = [];
     for (const w of app.windows()) {
       const windowId = String(w.id());
@@ -49,17 +51,16 @@ async function getPageContent(
   tab?: TabRef | null
 ): Promise<TabContent> {
   const script = `
-    const app = Application(${jsonStringLiteral(applicationName)});
-    const target = ${tab ? jsonStringLiteral(JSON.stringify(tab)) : "null"};
+    const app = Application(${jsonLiteral(applicationName)});
+    const target = ${tab ? jsonLiteral(tab) : "null"};
 
     // Chrome's "execute javascript" may hang on suspended tabs. JXA cannot
     // express AppleScript's "with timeout" block, so use a short process
     // timeout and do not retry this operation.
     let targetTab;
     if (target) {
-      const t = JSON.parse(target);
-      const win = app.windows.byId(Number(t.windowId));
-      targetTab = win.tabs.byId(Number(t.tabId));
+      const win = app.windows.byId(Number(target.windowId));
+      targetTab = win.tabs.byId(Number(target.tabId));
     } else {
       for (const w of app.windows()) {
         const t = w.activeTab();
@@ -89,9 +90,9 @@ async function getPageContent(
 
 async function openURL(applicationName: string, url: string): Promise<TabRef> {
   const script = `
-    const app = Application(${jsonStringLiteral(applicationName)});
+    const app = Application(${jsonLiteral(applicationName)});
     const win = app.windows[0];
-    const newTab = app.Tab({ url: ${jsonStringLiteral(url)} });
+    const newTab = app.Tab({ url: ${jsonLiteral(url)} });
     win.tabs.push(newTab);
     JSON.stringify({
       windowId: String(win.id()),

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -9,10 +9,12 @@ and a headless Chrome launched by Playwright MCP), AppleScript's
 `tell application "Google Chrome"` resolves to the newest-launched process,
 which may not be the user's foreground Chrome.
 
-JXA's `Application("Google Chrome")` resolves to the oldest-launched process
-instead, which reliably points to the user's primary Chrome in the common case.
-There is no public API to target a specific PID without ObjC bridging, so we
-rely on this JXA behavior documented at https://www.deanishe.net/snippet/multiple-app-instances/
+JXA has been observed to resolve `Application("Google Chrome")` to the
+oldest-launched process, which usually points to the user's primary Chrome.
+This is a startup-order heuristic: if the headless process starts first, it is
+selected instead. There is no public API to target a specific PID without ObjC
+bridging, so we rely on this behavior documented at
+https://www.deanishe.net/snippet/multiple-app-instances/
 */
 
 function jsonStringLiteral(value: string): string {
@@ -51,8 +53,8 @@ async function getPageContent(
     const target = ${tab ? jsonStringLiteral(JSON.stringify(tab)) : "null"};
 
     // Chrome's "execute javascript" may hang on suspended tabs. JXA cannot
-    // express AppleScript's "with timeout" block, so we rely on osascript's
-    // outer process timeout and the retry wrapper.
+    // express AppleScript's "with timeout" block, so use a short process
+    // timeout and do not retry this operation.
     let targetTab;
     if (target) {
       const t = JSON.parse(target);
@@ -77,7 +79,10 @@ async function getPageContent(
     JSON.stringify(result);
   `;
 
-  const scriptResult = await executeJXA(script);
+  const scriptResult = await executeJXA(script, {
+    timeout: 3 * 1000,
+    maxRetries: 0,
+  });
   const parsed = JSON.parse(scriptResult) as TabContent;
   return parsed;
 }

--- a/src/browser/osascript.ts
+++ b/src/browser/osascript.ts
@@ -51,19 +51,28 @@ export async function executeAppleScript(script: string): Promise<string> {
   });
 }
 
-export async function executeJXA(script: string): Promise<string> {
+export type ExecuteJXAOptions = {
+  timeout?: number;
+  maxRetries?: number;
+  retryDelay?: number;
+};
+
+export async function executeJXA(
+  script: string,
+  options: ExecuteJXAOptions = {}
+): Promise<string> {
   return retry(async () => {
     const { stdout, stderr } = await execFileAsync(
       "osascript",
       ["-l", "JavaScript", "-e", script],
       {
-        timeout: 5 * 1000,
+        timeout: options.timeout ?? 5 * 1000,
         maxBuffer: 10 * 1024 * 1024, // 10MB
       }
     );
     if (stderr) console.error("JXA stderr:", stderr);
     return stdout.trim();
-  });
+  }, options);
 }
 
 export function separator(): string {

--- a/src/browser/osascript.ts
+++ b/src/browser/osascript.ts
@@ -51,6 +51,21 @@ export async function executeAppleScript(script: string): Promise<string> {
   });
 }
 
+export async function executeJXA(script: string): Promise<string> {
+  return retry(async () => {
+    const { stdout, stderr } = await execFileAsync(
+      "osascript",
+      ["-l", "JavaScript", "-e", script],
+      {
+        timeout: 5 * 1000,
+        maxBuffer: 10 * 1024 * 1024, // 10MB
+      }
+    );
+    if (stderr) console.error("JXA stderr:", stderr);
+    return stdout.trim();
+  });
+}
+
 export function separator(): string {
   const uniqueId = Math.random().toString(36).substring(2);
   return `<|SEP:${uniqueId}|>`;

--- a/tests/chrome.test.ts
+++ b/tests/chrome.test.ts
@@ -1,0 +1,119 @@
+import vm from "node:vm";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const executeJXA = vi.fn();
+
+vi.mock("../src/browser/osascript.js", () => ({ executeJXA }));
+
+const { chromeBrowser } = await import("../src/browser/chrome.js");
+
+function runJXAWithApplication(application: object) {
+  executeJXA.mockImplementation(async (script: string) => {
+    const Application = () => application;
+    return String(vm.runInNewContext(script, { Application }));
+  });
+}
+
+function makeTab(id: number, title: string, url: string) {
+  return {
+    id: () => id,
+    title: () => title,
+    url: () => url,
+  };
+}
+
+describe("chromeBrowser JXA callers", () => {
+  beforeEach(() => {
+    executeJXA.mockReset();
+  });
+
+  test("lists HTTP tabs and preserves JSON special characters", async () => {
+    const tabs = [
+      makeTab(42, 'A \\ "quoted"\ntitle', "https://example.test/?q=あ"),
+      makeTab(43, "ignored", "chrome://settings"),
+    ];
+    runJXAWithApplication({
+      windows: () => [{ id: () => 7, tabs: () => tabs }],
+    });
+
+    await expect(chromeBrowser.getTabList("Google Chrome")).resolves.toEqual([
+      {
+        windowId: "7",
+        tabId: "42",
+        title: 'A \\ "quoted"\ntitle',
+        url: "https://example.test/?q=あ",
+      },
+    ]);
+    expect(executeJXA).toHaveBeenCalledTimes(1);
+    expect(executeJXA.mock.calls[0][0]).toContain(
+      'Application("Google Chrome")'
+    );
+  });
+
+  test("reads explicit and active tabs with a short non-retrying timeout", async () => {
+    const explicitTab = makeTab(22, "Explicit", "https://explicit.test");
+    const activeTab = makeTab(23, "Active", "https://active.test");
+    const app = {
+      windows: Object.assign(() => [{ activeTab: () => activeTab }], {
+        byId: (id: number) => ({
+          tabs: {
+            byId: (tabId: number) =>
+              id === 5 && tabId === 22 ? explicitTab : undefined,
+          },
+        }),
+      }),
+      execute: (tab: object) =>
+        tab === explicitTab ? "<explicit>" : "<active>",
+    };
+    runJXAWithApplication(app);
+
+    await expect(
+      chromeBrowser.getPageContent("Google Chrome", {
+        windowId: "5",
+        tabId: "22",
+      })
+    ).resolves.toEqual({
+      title: "Explicit",
+      url: "https://explicit.test",
+      content: "<explicit>",
+    });
+    await expect(
+      chromeBrowser.getPageContent("Google Chrome")
+    ).resolves.toEqual({
+      title: "Active",
+      url: "https://active.test",
+      content: "<active>",
+    });
+
+    expect(executeJXA).toHaveBeenCalledTimes(2);
+    expect(executeJXA.mock.calls[0][1]).toEqual({
+      timeout: 3000,
+      maxRetries: 0,
+    });
+    expect(executeJXA.mock.calls[1][1]).toEqual({
+      timeout: 3000,
+      maxRetries: 0,
+    });
+  });
+
+  test("opens a URL with special characters and returns the created tab ID", async () => {
+    const newTab = makeTab(99, "", "");
+    const app = {
+      windows: [
+        {
+          id: () => 8,
+          tabs: { push: (tab: object) => expect(tab).toBe(newTab) },
+        },
+      ],
+      Tab: (properties: { url: string }) => {
+        expect(properties.url).toBe('https://example.test/?q="あ"');
+        return newTab;
+      },
+    };
+    runJXAWithApplication(app);
+
+    await expect(
+      chromeBrowser.openURL("Google Chrome", 'https://example.test/?q="あ"')
+    ).resolves.toEqual({ windowId: "8", tabId: "99" });
+  });
+});

--- a/tests/integration/browser.e2e.ts
+++ b/tests/integration/browser.e2e.ts
@@ -1,34 +1,123 @@
 import { test as base, expect, devices } from "@playwright/test";
 import { getInterface, BrowserInterface } from "../../src/browser/browser.js";
+import { execFile } from "node:child_process";
+import { access } from "node:fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 type MyFixtures = {
   applicationName: string;
   browserInterface: BrowserInterface;
+  testMarker: string;
 };
 
-// Note: Safari support could be implemented, but Playwright's webkit cannot execute AppleScript
+function appBundlePath(executablePath: string): string {
+  const macOSDirectory = path.dirname(executablePath);
+  const contentsDirectory = path.dirname(macOSDirectory);
+  return path.resolve(path.dirname(contentsDirectory));
+}
+
+async function assertBrowserIsNotRunning(
+  executablePath: string
+): Promise<void> {
+  const executableName = path.basename(executablePath);
+  try {
+    await execFileAsync("pgrep", ["-x", executableName]);
+  } catch (error: unknown) {
+    // pgrep exits with status 1 when no process matches.
+    if (
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      error.code === 1
+    ) {
+      return;
+    }
+    throw new Error(
+      `Unable to check whether ${executableName} is running before the E2E test. ` +
+        "Run this test on macOS with pgrep available.",
+      { cause: error }
+    );
+  }
+
+  throw new Error(
+    `${executableName} is already running. Quit the Playwright test browser before ` +
+      "running the browser integration tests; normal Google Chrome can remain open."
+  );
+}
+
+async function getBundledBrowserExecutable(
+  executablePath: string
+): Promise<string> {
+  try {
+    await access(executablePath);
+  } catch (error: unknown) {
+    throw new Error(
+      `Playwright's bundled Chromium browser was not found at ${executablePath}. ` +
+        "Install it with `npx playwright install chromium` before running E2E tests.",
+      { cause: error }
+    );
+  }
+  return executablePath;
+}
+
+// The E2E fixture targets Chrome; Safari and Arc require browser-specific manual checks.
 const test = base.extend<MyFixtures>({
-  context: async ({ playwright }, use) => {
+  context: async ({ playwright, headless, testMarker }, use) => {
+    const executablePath = await getBundledBrowserExecutable(
+      playwright.chromium.executablePath()
+    );
+    await assertBrowserIsNotRunning(executablePath);
     const __dirname = path.dirname(fileURLToPath(import.meta.url));
     const profilePath = path.resolve(__dirname, "chrome-profile");
     const context = await playwright.chromium.launchPersistentContext(
-      profilePath, // to keep AppleScript enabled
+      profilePath, // Preferences enables JavaScript from Apple Events
       {
         ...devices["Desktop Chrome"],
-        channel: "chrome",
+        executablePath,
+        headless,
       }
     );
-    await use(context);
-    await context.close();
+    try {
+      const markerUrl = `https://mcp-chrome-tabs-e2e.invalid/${encodeURIComponent(testMarker)}`;
+      await context.route(markerUrl, (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "text/html",
+          body: `<title>${testMarker}</title><p>E2E marker</p>`,
+        })
+      );
+      const markerPage = await context.newPage();
+      await markerPage.goto(markerUrl, { waitUntil: "domcontentloaded" });
+      await markerPage.bringToFront();
+      await use(context);
+    } finally {
+      await context.close();
+    }
   },
-  browserInterface: async ({}, use) => {
+  browserInterface: async ({ context, applicationName, testMarker }, use) => {
     const browser = getInterface("chrome");
+    const tabs = await browser.getTabList(applicationName);
+    const markerUrl = `https://mcp-chrome-tabs-e2e.invalid/${encodeURIComponent(testMarker)}`;
+    if (
+      !context.pages().some((page) => page.url() === markerUrl) ||
+      !tabs.some((tab) => tab.url === markerUrl)
+    ) {
+      throw new Error(
+        `Test Chrome marker ${testMarker} was not found through getTabList; ` +
+          "refusing to operate on an unknown Chrome process."
+      );
+    }
     await use(browser);
   },
-  applicationName: async ({}, use) => {
-    await use("Google Chrome");
+  applicationName: async ({ playwright }, use) => {
+    await use(appBundlePath(playwright.chromium.executablePath()));
+  },
+  testMarker: async ({}, use) => {
+    await use(`mcp-chrome-tabs-e2e-${process.pid}-${Date.now()}`);
   },
 });
 

--- a/tests/osascript.test.ts
+++ b/tests/osascript.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const execFile = vi.fn();
+
+vi.mock("child_process", () => ({ execFile }));
+
+const { executeJXA } = await import("../src/browser/osascript.js");
+
+describe("executeJXA", () => {
+  beforeEach(() => {
+    execFile.mockReset();
+  });
+
+  test("uses the configured timeout and does not retry when maxRetries is zero", async () => {
+    execFile.mockImplementation((...args: unknown[]) => {
+      const callback = args.at(-1) as (
+        error: Error,
+        stdout: string,
+        stderr: string
+      ) => void;
+      callback(new Error("timed out"), "", "");
+    });
+
+    await expect(
+      executeJXA("slow script", { timeout: 3000, maxRetries: 0 })
+    ).rejects.toThrow("timed out");
+
+    expect(execFile).toHaveBeenCalledTimes(1);
+    expect(execFile.mock.calls[0][2]).toMatchObject({ timeout: 3000 });
+  });
+
+  test("keeps the default retry behavior", async () => {
+    execFile
+      .mockImplementationOnce((...args: unknown[]) => {
+        const callback = args.at(-1) as (
+          error: Error,
+          stdout: string,
+          stderr: string
+        ) => void;
+        callback(new Error("transient failure"), "", "");
+      })
+      .mockImplementationOnce((...args: unknown[]) => {
+        const callback = args.at(-1) as (
+          error: null,
+          result: { stdout: string; stderr: string }
+        ) => void;
+        callback(null, { stdout: " result \n", stderr: "" });
+      });
+
+    await expect(
+      executeJXA("retryable script", { retryDelay: 0 })
+    ).resolves.toBe("result");
+
+    expect(execFile).toHaveBeenCalledTimes(2);
+    expect(execFile.mock.calls[0][2]).toMatchObject({ timeout: 5000 });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes an issue where, when multiple Chrome processes share the same bundle ID (`com.google.Chrome`), AppleScript's `tell application "Google Chrome"` selects the **most recently launched** process, leaving the user's actual Chrome tabs unreachable.

This happens in practice when another tool (e.g. Playwright MCP) launches a headless Chrome — Apple Events end up going to that process instead.

The Chrome implementation now uses JXA (`osascript -l JavaScript`) instead of AppleScript. JXA's `Application("Google Chrome")` has been observed to select the oldest-launched process, which is normally the user's primary Chrome. Safari and Arc remain on AppleScript.

## Changes

### `src/browser/chrome.ts` — migrate to JXA

- Rewrote `getTabList`, `getPageContent`, and `openURL` in JXA
- Replaced separator-based string parsing with `JSON.stringify` inside JXA, so tab titles and URLs can no longer collide with a separator
- Values are embedded as JSON literals via `jsonLiteral()`, preventing input from breaking out of the surrounding script syntax
- Documented the rationale in a file-level comment, including the fact that this is a startup-order heuristic rather than an official API

### `src/browser/osascript.ts` — add `executeJXA`

Adds a JXA execution helper accepting `timeout`, `maxRetries`, and `retryDelay`. The existing `executeAppleScript`, `escapeAppleScript`, and `separator` are kept, since Safari and Arc still use them.

### Timeout handling

JXA has no equivalent of AppleScript's `with timeout` block. To guard against `execute javascript` hanging on suspended tabs, page content extraction uses a 3-second `execFile` timeout with `maxRetries: 0`.

Note the semantic difference: `with timeout` bounds only the Apple Event response wait, whereas the `execFile` timeout bounds the entire `osascript` process. Measurements across 20 tabs show a clean split between normal responses and hangs, with nothing in between, so 3 seconds leaves ample margin on both sides:

| Category | Count | Duration |
| --- | --- | --- |
| Normal | 16 | 124–225ms (216ms even for a 5MB Gmail tab; nearly independent of DOM size) |
| Suspended | 4 | No response even after 10s |

`osascript` startup overhead is 40–50ms. Raising the timeout would not rescue any tab — it would only lengthen the wait on hangs. This rationale is recorded in `docs/jxa-migration.md`.

### Tests

- `tests/chrome.test.ts` (new) — replaces JXA's `Application` with a mock inside `vm` to verify the generated scripts. Does not launch real JXA or Chrome
- `tests/osascript.test.ts` (new) — verifies `executeJXA`'s timeout and retry settings
- `tests/integration/browser.e2e.ts` — E2E now targets Playwright's bundled Chromium (`Google Chrome for Testing.app`, a separate bundle). It checks for a duplicate instance with `pgrep -x` before launching, then confirms a unique marker on a dedicated URL is visible through both the Playwright context and `getTabList` before operating. If the target process cannot be identified, the test aborts — so it **will not operate on the user's regular Chrome**

### Documentation

- `docs/jxa-migration.md` — trimmed to the migration design and verification points (178 → 74 lines)
- `README.md` — added a note about the multiple-process caveat; changed "AppleScript" to "Apple Events (JXA/AppleScript)"

## Verification

- Reproduced the bug and confirmed the fix on a real machine: with two same-bundle-ID Chrome processes running, AppleScript selected the newer process (1 tab) while JXA selected the oldest user Chrome (20 tabs)
- `npm run test` — 38 tests passed
- `npm run build` / `tsc --noEmit` — succeeded
- `npx prettier --check` — changed files are formatted
- Verified both `getPageContent` paths (explicit `TabRef` and active tab) against real Chrome

## Notes

- JXA's process selection is a startup-order heuristic, not an official API ([deanishe.net investigation](https://www.deanishe.net/snippet/multiple-app-instances/)). If another process starts before the target Chrome, that one may be selected instead. Pinning the Apple Event target by PID would require an Objective-C bridge, which is not used here because it prevents resolving Chrome's sdef from JXA
- The reverse launch order (another process started before the user's Chrome) is untested, as verifying it would require quitting the user's Chrome
- Safari and Arc have not been migrated to JXA. Considerations for doing so are collected in `docs/jxa-migration.md`
